### PR TITLE
Update declarative imports for SQLAlchemy 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ for a Pydantic model:
 
 ```python
 # models.py
-from sqlalchemy import Column, Integer, String
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column, Integer, String, __version__
+if __version__ < '1.4.0':
+    from sqlalchemy.ext.declarative import declarative_base
+else:
+    from sqlalchemy.orm import declarative_base
 import pydantic as v
 
 # SqlAlchemy models

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build = 'build.py'  # PyPi does not accept binary packages
 
 [tool.poetry.dependencies]
 python = "^3.7"
-sqlalchemy = "^1.3.5"
+sqlalchemy = "~1.3"
 pydantic = {version = "^1.5,!=1.6", optional = true}
 
 [tool.poetry.dev-dependencies]

--- a/sa2schema/pluck.py
+++ b/sa2schema/pluck.py
@@ -18,8 +18,11 @@ import warnings
 import enum
 from functools import lru_cache
 from typing import Mapping, Union, Any, Callable, FrozenSet
-
-from sqlalchemy.ext.declarative.api import DeclarativeMeta
+from sqlalchemy import __version__
+if __version__ < '1.4.0':
+    from sqlalchemy.ext.declarative.api import DeclarativeMeta
+else:
+    from sqlalchemy.orm import DeclarativeMeta
 from sqlalchemy.orm import Mapper
 from sqlalchemy.orm.base import instance_dict, class_mapper
 

--- a/tests/db.py
+++ b/tests/db.py
@@ -1,8 +1,11 @@
 from typing import Tuple
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, __version__
 from sqlalchemy.engine import Engine
-from sqlalchemy.ext.declarative import DeclarativeMeta
+if __version__ < '1.4.0':
+    from sqlalchemy.ext.declarative.api import DeclarativeMeta
+else:
+    from sqlalchemy.orm import DeclarativeMeta
 from sqlalchemy.orm import sessionmaker
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,9 +3,12 @@ from enum import Enum
 from typing import Optional
 
 import sqlalchemy as sa
+if sa.__version__ < '1.4.0':
+    from sqlalchemy.ext.declarative import declarative_base
+else:
+    from sqlalchemy.orm import declarative_base
 from sqlalchemy import select
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property, hybrid_method
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm.collections import attribute_mapped_collection, mapped_collection

--- a/tests/test_README.py
+++ b/tests/test_README.py
@@ -3,8 +3,11 @@
 # models.py
 import pytest
 from pydantic import BaseModel
-from sqlalchemy import Column, Integer, String, ForeignKey
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column, Integer, String, ForeignKey, __version__
+if __version__ < '1.4.0':
+    from sqlalchemy.ext.declarative import declarative_base
+else:
+    from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import relationship, Session
 import pydantic as v
 

--- a/tests/test_pluck.py
+++ b/tests/test_pluck.py
@@ -1,6 +1,9 @@
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.ext.declarative import declarative_base
+if sa.__version__ < '1.4.0':
+    from sqlalchemy.ext.declarative import declarative_base
+else:
+    from sqlalchemy.orm import declarative_base
 
 import sa2schema as sa2
 from .lib import sa_set_committed_state

--- a/tests/test_sa_to_pydantic.py
+++ b/tests/test_sa_to_pydantic.py
@@ -31,9 +31,9 @@ from .lib import sa_set_committed_state
 # Pydantic Version
 PD_VERSION = version.parse(pd.VERSION)
 
-# Pydantic < 1.7.3 report "required-optional" default values as None.
-# Newer versions report it as Ellipsis
-REQOPT_DEFAULT = None if PD_VERSION < version.parse('1.7.3') else ...
+# Pydantic < 1.7.3 and >= 1.8.2 report "required-optional" default values as None.
+# Other versions report it as Ellipsis.
+REQOPT_DEFAULT = None if PD_VERSION < version.parse('1.7.3') or PD_VERSION >= version.parse('1.8.2') else ...
 
 
 

--- a/tests/test_sa_to_pydantic.py
+++ b/tests/test_sa_to_pydantic.py
@@ -8,7 +8,10 @@ from pydantic.fields import SHAPE_LIST, ModelField
 from pydantic.utils import GetterDict
 import pydantic as pd
 import sqlalchemy as sa
-from sqlalchemy.ext.declarative import declarative_base
+if sa.__version__ < '1.4.0':
+    from sqlalchemy.ext.declarative import declarative_base
+else:
+    from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import exc as sa_exc, Session, load_only, joinedload
 from sqlalchemy.orm.attributes import set_committed_value
 from sqlalchemy.orm.base import instance_state
@@ -434,7 +437,10 @@ def test_sa_model_user_relationships_in_annotations():
 
     # Declare some models
     import sqlalchemy as sa
-    from sqlalchemy.ext.declarative import declarative_base
+    if sa.__version__ < '1.4.0':
+        from sqlalchemy.ext.declarative import declarative_base
+    else:
+        from sqlalchemy.orm import declarative_base
 
     Base = declarative_base()
 

--- a/tests/test_stubgen.py
+++ b/tests/test_stubgen.py
@@ -3,7 +3,10 @@ import sys
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.ext.declarative import declarative_base
+if sa.__version__ < '1.4.0':
+    from sqlalchemy.ext.declarative import declarative_base
+else:
+    from sqlalchemy.orm import declarative_base
 
 from sa2schema import AttributeType
 from sa2schema.to.pydantic import Models


### PR DESCRIPTION
Closes kolypto/py-sa2schema#2

The SQLAlchemy version in _pyproject.toml_, `sqlalchemy = "^1.3.5"`, permits installation of versions between 1.3.5 and 2.

In SQLAlchemy 1.4, the [declarative API](https://docs.sqlalchemy.org/en/14/orm/extensions/declarative/api.html) was [integrated](https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#declarative-is-now-integrated-into-the-orm-with-new-features) into the [ORM mapping API](https://docs.sqlalchemy.org/en/14/orm/mapping_api.html).

This PR will update imports from the declarative API for SQLAlchemy 1.4, and restrict the SQLAlchemy version to 1.3 until further updates are made. There was also a small update needed to get the tests passing, because _pydantic_ required optional fields are now `None` again (see samuelcolvin/pydantic@c18634b).

I have some experience with SQLAlchemy 1.4, and I'm happy to continue helping with more updates to this project.
